### PR TITLE
fix python version setting in Image/environment.yaml for MultiScaleDeformableAttention package

### DIFF
--- a/Image/environment.yaml
+++ b/Image/environment.yaml
@@ -13,7 +13,7 @@ dependencies:
   - ncurses=6.4=h6a678d5_0
   - openssl=3.0.8=h7f8727e_0
   - pip=23.1.2=py38h06a4308_0
-  - python=3.8.16=h955ad1f_4
+  - python=3.9.18=h955ad1f_0
   - readline=8.2=h5eee18b_0
   - setuptools=67.8.0=py38h06a4308_0
   - sqlite=3.41.2=h5eee18b_0


### PR DESCRIPTION
Using Python3.8 will not find suitable version of MultiScaleDeformableAttention package, and installation failed.
It works after upgrade Python version.